### PR TITLE
feat: improve token refresh

### DIFF
--- a/custom_components/bose/const.py
+++ b/custom_components/bose/const.py
@@ -4,4 +4,10 @@ import logging
 
 DOMAIN = "bose"
 
+# Token Refresh Delay is how long between each check if the token is valid
+# Token Retry Delay is how long before each retry if refresh fails
+TOKEN_REFRESH_DELAY = 3600 # seconds
+TOKEN_RETRY_DELAY = 120 # seconds
+
+
 _LOGGER = logging.getLogger("bose")


### PR DESCRIPTION
This PR does two things:

- It decreases the delay between successful token refreshes, as tokens might have a shorter lifetime than 6 hours.

Now we check every 1 hour if the token is still valid for at least 2 hours. If not, we refresh.  If it is valid, we go back to sleep.

- We also always add a delay (120 seconds) between token refresh no matter what, to ensure that we don't flood the auth-server with requests in case of errors.