### PR TITLE
feat: link media player to sources

### DIFF
--- a/custom_components/bose/manifest.json
+++ b/custom_components/bose/manifest.json
@@ -15,7 +15,7 @@
     "pychromecast>=13.0.0"
   ],
   "ssdp": [],
-  "version": "1.2.1",
+  "version": "1.3.0",
   "zeroconf": [
     "_bose-passport._tcp.local."
   ]

--- a/custom_components/bose/strings.json
+++ b/custom_components/bose/strings.json
@@ -6,6 +6,7 @@
       "connect_failed": "Failed to connect to the speaker. Make sure the speaker is powered on, connected, and that the IP address is correct.",
       "info_failed": "Connection to the device established, but retrieving speaker information failed. Check the logs for more details.",
       "no_guid": "Device discovery failed: no GUID found in discovery information.",
+      "no_sources_available": "No sources available to configure. Sources like TV, Optical, and Cinch can be linked to other media players for playback information.",
       "reauth_failed": "Reauthentication failed. Please try removing and re-adding the device.",
       "reauth_successful": "Successfully reauthenticated with your Bose account.",
       "wrong_account": "The account you entered does not match the account used when setting up this device. Please use the same account."
@@ -39,6 +40,25 @@
         "data": {
           "mail": "Email address of your BOSE account",
           "password": "Password of your BOSE account"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Select source to configure",
+        "description": "Choose which source you want to configure. You can link a media player to show playback information and optionally rename the source.",
+        "data": {
+          "source": "Source"
+        }
+      },
+      "configure_source": {
+        "title": "Configure {source_name}",
+        "description": "Configure settings for source: {source_name}",
+        "data": {
+          "rename": "Custom name (optional)",
+          "linked_player": "Linked media player (optional)"
         }
       }
     }

--- a/custom_components/bose/translations/de.json
+++ b/custom_components/bose/translations/de.json
@@ -6,6 +6,7 @@
       "connect_failed": "Verbindung zum Lautsprecher fehlgeschlagen. Prüfe, ob der Lautsprecher eingeschaltet und verbunden ist und ob die IP‑Adresse korrekt ist.",
       "info_failed": "Verbindung zum Gerät hergestellt, aber das Abrufen der Lautsprecherinformationen ist fehlgeschlagen. Prüf die Protokolle für mehr Informationen.",
       "no_guid": "Geräteerkennung fehlgeschlagen: Keine GUID in den Erkennungsinformationen gefunden.",
+      "no_sources_available": "Keine Quellen zum Konfigurieren verfügbar. Quellen wie TV, Optical und Cinch können mit anderen Media-Playern für Wiedergabeinformationen verknüpft werden.",
       "reauth_failed": "Erneute Authentifizierung fehlgeschlagen. Bitte versuche, das Gerät zu entfernen und erneut hinzuzufügen.",
       "reauth_successful": "Erfolgreich mit deinem Bose-Konto erneut authentifiziert.",
       "wrong_account": "Das eingegebene Konto stimmt nicht mit dem Konto überein, das beim Einrichten dieses Geräts verwendet wurde. Bitte verwende dasselbe Konto."
@@ -39,6 +40,25 @@
         "data": {
           "mail": "E‑Mail‑Adresse deines BOSE‑Kontos",
           "password": "Passwort deines BOSE‑Kontos"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Quelle zum Konfigurieren auswählen",
+        "description": "Wähle die Quelle aus, die du konfigurieren möchtest. Du kannst einen Media-Player verknüpfen, um Wiedergabeinformationen anzuzeigen, und optional die Quelle umbenennen.",
+        "data": {
+          "source": "Quelle"
+        }
+      },
+      "configure_source": {
+        "title": "{source_name} konfigurieren",
+        "description": "Einstellungen für Quelle konfigurieren: {source_name}",
+        "data": {
+          "rename": "Benutzerdefinierter Name (optional)",
+          "linked_player": "Verknüpfter Media-Player (optional)"
         }
       }
     }

--- a/custom_components/bose/translations/en.json
+++ b/custom_components/bose/translations/en.json
@@ -4,7 +4,8 @@
             "already_configured": "Device is already configured",
             "auth_failed": "Authentication with your BOSE account failed. Please check your email address and password.",
             "connect_failed": "Failed to connect to the speaker. Make sure the speaker is powered on, connected, and that the IP address is correct.",
-            "info_failed": "Connection to the device established, but retrieving speaker information failed. Check the logs for more details."
+            "info_failed": "Connection to the device established, but retrieving speaker information failed. Check the logs for more details.",
+            "no_sources_available": "No sources available to configure. Sources like TV, Optical, and Cinch can be linked to other media players for playback information."
         },
         "error": {
             "auth_failed": "Authentication with your BOSE account failed. Please check your email address and password."
@@ -21,6 +22,25 @@
                     "mail": "Email address of your BOSE account",
                     "manual_ip": "Enter IP address manually",
                     "password": "Password of your BOSE account"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Select source to configure",
+                "description": "Choose which source you want to configure. You can link a media player to show playback information and optionally rename the source.",
+                "data": {
+                    "source": "Source"
+                }
+            },
+            "configure_source": {
+                "title": "Configure {source_name}",
+                "description": "Configure settings for source: {source_name}",
+                "data": {
+                    "rename": "Custom name (optional)",
+                    "linked_player": "Linked media player (optional)"
                 }
             }
         }

--- a/custom_components/bose/translations/es.json
+++ b/custom_components/bose/translations/es.json
@@ -43,6 +43,25 @@
       }
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Seleccionar fuente para configurar",
+        "description": "Elige qué fuente deseas configurar. Puedes vincular un reproductor multimedia para mostrar información de reproducción y, opcionalmente, cambiar el nombre de la fuente.",
+        "data": {
+          "source": "Fuente"
+        }
+      },
+      "configure_source": {
+        "title": "Configurar {source_name}",
+        "description": "Configurar ajustes para la fuente: {source_name}",
+        "data": {
+          "rename": "Nombre personalizado (opcional)",
+          "linked_player": "Reproductor multimedia vinculado (opcional)"
+        }
+      }
+    }
+  },
   "entity": {
     "binary_sensor": {
       "charging_state": {

--- a/custom_components/bose/translations/it.json
+++ b/custom_components/bose/translations/it.json
@@ -43,6 +43,25 @@
       }
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Seleziona sorgente da configurare",
+        "description": "Scegli quale sorgente desideri configurare. Puoi collegare un lettore multimediale per mostrare le informazioni di riproduzione e rinominare facoltativamente la sorgente.",
+        "data": {
+          "source": "Sorgente"
+        }
+      },
+      "configure_source": {
+        "title": "Configura {source_name}",
+        "description": "Configura le impostazioni per la sorgente: {source_name}",
+        "data": {
+          "rename": "Nome personalizzato (facoltativo)",
+          "linked_player": "Lettore multimediale collegato (facoltativo)"
+        }
+      }
+    }
+  },
   "entity": {
     "binary_sensor": {
       "charging_state": {


### PR DESCRIPTION
## Source Renaming
Physical sources (TV, Optical, Cinch) can now be assigned custom names for better identification.

## Media Player Synchronization
Sources can be linked to existing media player entities to display their playback information. When linked:
- The BOSE media player shows metadata from the linked entity (e.g., current track, album art)
- Playback controls (play/pause, next, previous, seek) are forwarded to the linked entity

**Example:** Link the "TV" source to your Apple TV media player entity - the BOSE speaker will now display what's playing on Apple TV and allow you to control it directly.