### PR TITLE
fix: source switching, device_id handling, and supported features

### DIFF
--- a/custom_components/bose/__init__.py
+++ b/custom_components/bose/__init__.py
@@ -405,27 +405,24 @@ def setup(hass: HomeAssistant, config: ConfigEntry) -> bool:
     """Set up the Bose component."""
 
     async def handle_custom_request(call: ServiceCall) -> ServiceResponse:
-        # Extract device_id from target
-        ha_device_ids = call.data.get("device_id", [])  # Always returns a list
-        if not ha_device_ids:
+        raw_device_id = call.data.get("device_id")
+        _LOGGER.debug(
+            "send_custom_request: device_id=%r (type=%s), all data keys=%s",
+            raw_device_id,
+            type(raw_device_id).__name__,
+            list(call.data.keys()),
+        )
+        if not raw_device_id:
             raise ValueError("No valid target device provided.")
 
-        ha_device_id = ha_device_ids[
-            0
-        ]  # Take the first device in case of multiple selections
+        if isinstance(raw_device_id, list):
+            ha_device_id = raw_device_id[0]
+        else:
+            ha_device_id = str(raw_device_id)
 
         resource = call.data["resource"]
         method = call.data["method"]
         body = call.data.get("body", {})
-
-        # Find the matching speaker instance based on Home Assistant device_id
-        device_registry = dr.async_get(hass)
-        device_entry = device_registry.async_get(ha_device_id)
-
-        if not device_entry:
-            raise ValueError(
-                f"No device found in Home Assistant for device_id: {ha_device_id}"
-            )
 
         device_registry = dr.async_get(hass)
         device_entry = device_registry.async_get(ha_device_id)

--- a/custom_components/bose/media_player.py
+++ b/custom_components/bose/media_player.py
@@ -484,7 +484,8 @@ class BoseMediaPlayer(BoseBaseEntity, MediaPlayerEntity):
             bluetooth_device = self._bluetooth_devices[active_device]
             self._attr_source = f"Bluetooth: {bluetooth_device['name']}"
             self.async_write_ha_state()
-            self._attr_source_list.append(self._attr_source)
+            if self._attr_source not in self._attr_source_list:
+                self._attr_source_list.append(self._attr_source)
 
     async def async_update(self) -> None:
         """Fetch new state data from the speaker."""
@@ -521,13 +522,15 @@ class BoseMediaPlayer(BoseBaseEntity, MediaPlayerEntity):
         # Refresh available sources (build human readable list)
         sources = await self.coordinator.get_sources()
         for source in sources.get("sources", []):
+            is_available = source.get("status") in ("AVAILABLE", "NOT_CONFIGURED")
+            is_tv_source = (
+                source.get("sourceName") == "PRODUCT"
+                and source.get("sourceAccountName") == "TV"
+            )
             if (
-                (
-                    source.get("status", None) in ("AVAILABLE", "NOT_CONFIGURED")
-                    or source.get("accountId", "TV")
-                )
-                and source.get("sourceAccountName", None)
-                and source.get("sourceName", None)
+                (is_available or is_tv_source)
+                and source.get("sourceAccountName")
+                and source.get("sourceName")
             ):
                 if source.get("sourceName", None) in (
                     "AMAZON",
@@ -600,7 +603,19 @@ class BoseMediaPlayer(BoseBaseEntity, MediaPlayerEntity):
 
         # Handle regular sources
         if original_source not in self._available_sources:
-            return
+            _LOGGER.warning(
+                "Source '%s' not found in available sources: %s",
+                original_source,
+                list(self._available_sources.keys()),
+            )
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="source_not_found",
+                translation_placeholders={
+                    "source_name": source,
+                    "available_sources": ", ".join(self._available_sources.keys()),
+                },
+            )
 
         source_data = self._available_sources[original_source]
 
@@ -1034,27 +1049,31 @@ class BoseMediaPlayer(BoseBaseEntity, MediaPlayerEntity):
 
             return bool(getattr(state, key, False))
 
-        if not now:
-            return MediaPlayerEntityFeature.PLAY
-
-        return (
+        base_features = (
             MediaPlayerEntityFeature.TURN_OFF
             | MediaPlayerEntityFeature.TURN_ON
+            | MediaPlayerEntityFeature.PLAY
+            | MediaPlayerEntityFeature.VOLUME_SET
+            | MediaPlayerEntityFeature.VOLUME_STEP
+            | MediaPlayerEntityFeature.VOLUME_MUTE
+            | MediaPlayerEntityFeature.GROUPING
+            | MediaPlayerEntityFeature.SELECT_SOURCE
+        )
+
+        if not now:
+            return base_features
+
+        return (
+            base_features
             | (MediaPlayerEntityFeature.NEXT_TRACK if _can("canSkipNext") else 0)
             | (MediaPlayerEntityFeature.PAUSE if _can("canPause") else 0)
-            | MediaPlayerEntityFeature.PLAY
             | (
                 MediaPlayerEntityFeature.PREVIOUS_TRACK
                 if _can("canSkipPrevious")
                 else 0
             )
             | (MediaPlayerEntityFeature.SEEK if _can("canSeek") else 0)
-            | MediaPlayerEntityFeature.VOLUME_SET
-            | MediaPlayerEntityFeature.VOLUME_STEP
-            | MediaPlayerEntityFeature.VOLUME_MUTE
             | (MediaPlayerEntityFeature.STOP if _can("canStop") else 0)
-            | MediaPlayerEntityFeature.GROUPING
-            | MediaPlayerEntityFeature.SELECT_SOURCE
             | (
                 (
                     MediaPlayerEntityFeature.PLAY_MEDIA

--- a/custom_components/bose/strings.json
+++ b/custom_components/bose/strings.json
@@ -221,6 +221,9 @@
     "source_not_configured": {
       "message": "Source {source_name} is not properly configured"
     },
+    "source_not_found": {
+      "message": "Source {source_name} is not available. Available sources: {available_sources}"
+    },
     "speaker_not_found": {
       "message": "No speaker found for device ID: {device_id}"
     }

--- a/custom_components/bose/translations/de.json
+++ b/custom_components/bose/translations/de.json
@@ -218,6 +218,9 @@
     "source_not_configured": {
       "message": "Quelle {source_name} ist nicht korrekt konfiguriert."
     },
+    "source_not_found": {
+      "message": "Quelle {source_name} ist nicht verfügbar. Verfügbare Quellen: {available_sources}"
+    },
     "chromecast_not_available": {
       "message": "Chromecast-Funktionalität für Lautsprecher unter {speaker_ip} nicht verfügbar"
     },

--- a/custom_components/bose/translations/en.json
+++ b/custom_components/bose/translations/en.json
@@ -258,6 +258,9 @@
         "source_not_configured": {
             "message": "Source {source_name} is not properly configured"
         },
+        "source_not_found": {
+            "message": "Source {source_name} is not available. Available sources: {available_sources}"
+        },
         "speaker_not_found": {
             "message": "No speaker found for device ID: {device_id}"
         }

--- a/custom_components/bose/translations/es.json
+++ b/custom_components/bose/translations/es.json
@@ -218,6 +218,9 @@
     "source_not_configured": {
       "message": "La fuente {source_name} no está configurada correctamente."
     },
+    "source_not_found": {
+      "message": "La fuente {source_name} no está disponible. Fuentes disponibles: {available_sources}"
+    },
     "chromecast_not_available": {
       "message": "Funcionalidad de Chromecast no disponible para el altavoz en {speaker_ip}"
     },

--- a/custom_components/bose/translations/it.json
+++ b/custom_components/bose/translations/it.json
@@ -218,6 +218,9 @@
     "source_not_configured": {
       "message": "La sorgente {source_name} non è configurata correttamente."
     },
+    "source_not_found": {
+      "message": "La sorgente {source_name} non è disponibile. Sorgenti disponibili: {available_sources}"
+    },
     "chromecast_not_available": {
       "message": "Funzionalità Chromecast non disponibile per l'altoparlante su {speaker_ip}"
     },


### PR DESCRIPTION
## Summary

- **Fix source dropdown not appearing**: `supported_features` now always includes
  `SELECT_SOURCE`, `VOLUME_*`, `TURN_ON/OFF`, and `GROUPING` even when
  `_now_playing_result` is empty (e.g. speaker off/standby or before first poll).
- **Fix source filter logic**: The condition `or source.get("accountId", "TV")` was
  always truthy, bypassing the status filter entirely. Replaced with an explicit
  check for the TV PRODUCT source.
- **Fix `send_custom_request` device_id handling**: The handler assumed `device_id`
  was always a list (`device_id[0]`), but the HA `device` selector returns a string.
  Now accepts both formats.
- **Add error feedback for unknown source selection**: `async_select_source` previously
  returned silently when a source wasn't found. Now raises `ServiceValidationError`
  with the list of available sources.
- **Fix duplicate Bluetooth source entries**: Added membership check before appending
  to `_attr_source_list` in `_async_update_active_bluetooth_source`.

## Test plan

- [x] Verified source dropdown appears in HA more-info dialog
- [x] Verified TV source switching works via dropdown and `media_player.select_source`
- [x] Verified `bose.send_custom_request` works with `device_id` as a plain string
- [x] Verified duplicate Bluetooth entries no longer appear in source list
- [x] Tested on Bose Soundbar 300 with subwoofer + 2 rear speakers